### PR TITLE
BLD: loosen numpy version requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,4 +2,4 @@ xtgeo>=2.14
 PyYAML
 scipy>=1.5.3
 matplotlib>=3.3.2
-numpy<1.24,>=1.19.2
+numpy>=1.19.2


### PR DESCRIPTION
Allow numpy > 1.23