### PR TITLE
BLD: Pin sphinx-autodoc-typehints < 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ docs = [
     "myst-parser",
     "sphinx",
     "sphinx-argparse",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints<2.4",
     "sphinx-copybutton",
     "sphinx-togglebutton",
     "sphinx_rtd_theme",


### PR DESCRIPTION
There's a dependency interaction with this version that causes documentation builds to fail.